### PR TITLE
fix: update eik/rollup-plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [22]
+        node-version: [22, 24]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
   ],
   "author": "Finn.no",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
-    "@eik/rollup-plugin": "4.0.66"
+    "@eik/rollup-plugin": "5.0.0"
   },
   "devDependencies": {
     "@eik/eslint-config": "1.0.13",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node 18.